### PR TITLE
divide tunnel network cidr dynamically

### DIFF
--- a/pkg/controller/tunnel/innercluster_tunnel_controller.go
+++ b/pkg/controller/tunnel/innercluster_tunnel_controller.go
@@ -65,7 +65,7 @@ func (ict *InnerClusterTunnelController) SpawnNewCIDRForNRIPod(pod *v1.Pod) (str
 	ict.Lock()
 	defer ict.Unlock()
 	existingCIDR := ict.existingCIDR
-	secondaryCIDR, allocateError := utils.FindAvailableCIDR(ict.clusterCIDR, existingCIDR, 24)
+	secondaryCIDR, allocateError := utils.FindClusterAvailableCIDR(ict.clusterCIDR, existingCIDR)
 	if allocateError != nil {
 		klog.Errorf("allocate form %s with error %v", existingCIDR, allocateError)
 		return "", allocateError

--- a/pkg/controller/tunnel/peer_controller.go
+++ b/pkg/controller/tunnel/peer_controller.go
@@ -162,7 +162,7 @@ func (p *PeerController) Handle(obj interface{}) (requeueAfter *time.Duration, e
 		}
 		// cidr allocation here.
 		cachedPeer.Spec.PodCIDR = make([]string, 1)
-		cachedPeer.Spec.PodCIDR[0], err = utils.FindAvailableCIDR(p.spec.CIDR, existingCIDR, 16)
+		cachedPeer.Spec.PodCIDR[0], err = utils.FindTunnelAvailableCIDR(p.spec.CIDR, existingCIDR)
 		if err != nil {
 			klog.Infof("allocate peer cidr failed %v", err)
 			return &failedPeriod, err

--- a/utils/netutil_test.go
+++ b/utils/netutil_test.go
@@ -85,7 +85,165 @@ func TestHosts(t *testing.T) {
 	}
 }
 
-func Test_findAvailableCIDR(t *testing.T) {
+func TestFindTunnelAvailableCIDR(t *testing.T) {
+	type args struct {
+		networkCIDR   string
+		existingPeers []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test /16~/13 CIDR",
+			args: args{
+				networkCIDR:   "10.0.0.0/16",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/18",
+			wantErr: false,
+		},
+		{
+			name: "test /12~/9 CIDR",
+			args: args{
+				networkCIDR:   "10.0.0.0/12",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/16",
+			wantErr: false,
+		},
+		{
+			name: "test >=/8 CIDR",
+			args: args{
+				networkCIDR:   "10.0.0.0/8",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/12",
+			wantErr: false,
+		},
+		{
+			name: "test /30 CIDR",
+			args: args{
+				networkCIDR:   "10.0.0.0/24",
+				existingPeers: []string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "test /16 CIDR",
+			args: args{
+				networkCIDR:   "10.0.0.0/16",
+				existingPeers: []string{"10.0.0.0/18"},
+			},
+			want:    "10.0.64.0/18",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FindTunnelAvailableCIDR(tt.args.networkCIDR, tt.args.existingPeers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindTunnelAvailableCIDR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FindTunnelAvailableCIDR() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindClusterAvailableCIDR(t *testing.T) {
+	type args struct {
+		tunnelCIDR    string // consistent test
+		networkCIDR   string
+		existingPeers []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test /16~/13 CIDR",
+			args: args{
+				tunnelCIDR:    "10.0.0.0/16",
+				networkCIDR:   "10.0.0.0/18",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/24",
+			wantErr: false,
+		},
+		{
+			name: "test /12~/9 CIDR",
+			args: args{
+				tunnelCIDR:    "10.0.0.0/12",
+				networkCIDR:   "10.0.0.0/16",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/24",
+			wantErr: false,
+		},
+		{
+			name: "test >=/8 CIDR",
+			args: args{
+				tunnelCIDR:    "10.0.0.0/8",
+				networkCIDR:   "10.0.0.0/12",
+				existingPeers: []string{},
+			},
+			want:    "10.0.0.0/22",
+			wantErr: false,
+		},
+		{
+			name: "test /24 CIDR",
+			args: args{
+				tunnelCIDR:    "10.0.0.0/24",
+				networkCIDR:   "10.0.0.0/24",
+				existingPeers: []string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "test /16 CIDR",
+			args: args{
+				tunnelCIDR:    "10.0.0.0/16",
+				networkCIDR:   "10.0.0.0/18",
+				existingPeers: []string{"10.0.0.0/24"},
+			},
+			want:    "10.0.1.0/24",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// consistent checking ahead
+			clusterCIDR, err := FindTunnelAvailableCIDR(tt.args.tunnelCIDR, []string{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindTunnelAvailableCIDR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && clusterCIDR != tt.args.networkCIDR {
+				t.Errorf("invalid test case")
+			}
+
+			got, err := FindClusterAvailableCIDR(tt.args.networkCIDR, tt.args.existingPeers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindClusterAvailableCIDR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FindClusterAvailableCIDR() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindAvailableCIDR(t *testing.T) {
 	type args struct {
 		networkCIDR   string
 		existingPeers []string
@@ -160,13 +318,13 @@ func Test_findAvailableCIDR(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FindAvailableCIDR(tt.args.networkCIDR, tt.args.existingPeers, tt.args.networkBits)
+			got, err := findAvailableCIDR(tt.args.networkCIDR, tt.args.existingPeers, tt.args.networkBits)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FindAvailableCIDR() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("findAvailableCIDR() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("FindAvailableCIDR() got = %v, want %v", got, tt.want)
+				t.Errorf("findAvailableCIDR() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
divide configured tunnel network cidr into 3 parts by cidr size for clusters, nodes per cluster, and pods per node.

dividing table is as follows:
| network-cidr | host-bits | peer-cluster-bits | peer-cluster-cidr | node-pod-bits | node-cidr | cluster-node-bits |
| -----------: | --------: | ----------------: | ----------------: | ------------: | --------: | ----------------: |
|      /16~/13 |     16~19 |                 2 |           /18~/15 |             8 |       /24 |               6~9 |
|       /12~/9 |     20-23 |                 4 |           /16~/13 |             8 |       /24 |              6~11 |
|         >=/8 |      >=24 |                 4 |             >=/12 |            10 |       /22 |             10~18 |

Close #110