### PR TITLE
Feat: Remove local syncer-operator namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
           path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
       - name: Cache go modules and build cache
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           # In order:
           # * Module download cache

--- a/cmd/proxy/app/proxy.go
+++ b/cmd/proxy/app/proxy.go
@@ -632,8 +632,13 @@ func (s *ProxyServer) Run() error {
 		return err
 	}
 
+	hasFleetServiceName, err := labels.NewRequirement(known.LabelServiceName, selection.Exists, nil)
+	if err != nil {
+		return err
+	}
+
 	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*noProxyName, *noHeadlessEndpoints)
+	labelSelector = labelSelector.Add(*noProxyName, *noHeadlessEndpoints, *hasFleetServiceName)
 
 	// Make informers that filter out objects that want a non-default service proxy.
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,

--- a/examples/client-import.yaml
+++ b/examples/client-import.yaml
@@ -36,10 +36,6 @@ apiVersion: multicluster.x-k8s.io/v1alpha1
 kind: ServiceImport
 metadata:
   name: nginx-svc
-  namespace: syncer-operator
-  labels:
-    services.fleetboard.io/multi-cluster-service-LocalNamespace: default
-    services.fleetboard.io/multi-cluster-service-name: nginx-svc
 spec:
   type: "ClusterSetIP"
   ports:

--- a/pkg/cnf/CNFManager.go
+++ b/pkg/cnf/CNFManager.go
@@ -158,7 +158,6 @@ func NewCNFManager(opts *tunnel.Options) (*Manager, error) {
 	serviceSyncer, errSyncer := syncer.New(&agentSpec, known.SyncerConfig{
 		LocalRestConfig: localConfig,
 		LocalClient:     dynamicLocalClient,
-		LocalNamespace:  agentSpec.LocalNamespace,
 		LocalClusterID:  agentSpec.ClusterID,
 	}, hubConfig)
 	if errSyncer != nil {

--- a/pkg/controller/syncer/agent.go
+++ b/pkg/controller/syncer/agent.go
@@ -31,8 +31,7 @@ type AgentConfig struct {
 }
 
 type Syncer struct {
-	ClusterID      string
-	LocalNamespace string
+	ClusterID string
 
 	HubKubeConfig           *rest.Config
 	SyncerConf              known.SyncerConfig
@@ -78,7 +77,6 @@ func New(spec *tunnel.Specification, syncerConf known.SyncerConfig, hubKubeConfi
 		return nil, err
 	}
 
-	syncerConf.LocalNamespace = spec.LocalNamespace
 	syncerConf.LocalClusterID = spec.ClusterID
 	syncerConf.RemoteNamespace = spec.ShareNamespace
 
@@ -88,7 +86,6 @@ func New(spec *tunnel.Specification, syncerConf known.SyncerConfig, hubKubeConfi
 		HubKubeConfig:           hubKubeConfig,
 		ServiceExportController: serviceExportController,
 		ServiceImportController: serviceImportController,
-		LocalNamespace:          syncerConf.LocalNamespace,
 		KubeInformerFactory:     kubeInformerFactory,
 		KubeClientSet:           localKubeClientSet,
 		McsInformerFactory:      mcsInformerFactory,
@@ -108,8 +105,7 @@ func (s *Syncer) Start(ctx context.Context) (err error) {
 
 	klog.Info("Starting Syncer and init virtual service CIDR...")
 	var cidr string
-	if cidr, err = s.ServiceImportController.IPAM.InitNewCIDR(s.LocalMcsClientSet,
-		s.LocalNamespace, s.KubeClientSet); err != nil {
+	if cidr, err = s.ServiceImportController.IPAM.InitNewCIDR(s.LocalMcsClientSet, s.KubeClientSet); err != nil {
 		klog.Errorf("we allocate for virtual service failed for %v", err)
 		return err
 	} else {

--- a/pkg/known/constants.go
+++ b/pkg/known/constants.go
@@ -7,7 +7,6 @@ import (
 const (
 	Fleetboard                = "fleetboard"
 	FleetboardSystemNamespace = "fleetboard-system"
-	SyncNamespace             = "syncer-operator"
 	HubClusterName            = "hub"
 	HubSecretName             = Fleetboard
 )

--- a/pkg/known/types.go
+++ b/pkg/known/types.go
@@ -12,7 +12,6 @@ type SyncerConfig struct {
 	// LocalClient the client used to access local resources to sync. This is optional and is provided for unit testing
 	// in lieu of the LocalRestConfig. If not specified, one is created from the LocalRestConfig.
 	LocalClient     dynamic.Interface
-	LocalNamespace  string
 	LocalClusterID  string
 	RemoteNamespace string
 }

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 	mcsinformer "sigs.k8s.io/mcs-api/pkg/client/informers/externalversions/apis/v1alpha1"
-
-	"github.com/fleetboard-io/fleetboard/pkg/known"
 )
 
 // ServiceImportHandler is an abstract interface of objects which receive
@@ -119,11 +117,6 @@ func (c *EndpointSliceConfig) handleAddEndpointSlice(obj interface{}) {
 		return
 	}
 	for _, h := range c.eventHandlers {
-		if endpointSlice.Namespace != known.SyncNamespace {
-			klog.Infof("EndpointSliceConfig.handleAddEndpointSlice will not deal: %v/%v",
-				endpointSlice.Namespace, endpointSlice.Name)
-			continue
-		}
 		klog.V(4).InfoS("Calling handler.OnEndpointSliceAdd", "endpointslice",
 			klog.KObj(endpointSlice))
 		h.OnEndpointSliceAdd(endpointSlice)
@@ -142,11 +135,6 @@ func (c *EndpointSliceConfig) handleUpdateEndpointSlice(oldObj, newObj interface
 		return
 	}
 	for _, h := range c.eventHandlers {
-		if newEndpointSlice.Namespace != known.SyncNamespace {
-			klog.Infof("EndpointSliceConfig.handleUpdateEndpointSlice will not deal: %v/%v",
-				newEndpointSlice.Namespace, newEndpointSlice.Name)
-			continue
-		}
 		klog.V(4).InfoS("Calling handler.OnEndpointSliceUpdate", "endpointslice",
 			klog.KObj(newEndpointSlice))
 		h.OnEndpointSliceUpdate(oldEndpointSlice, newEndpointSlice)
@@ -167,12 +155,6 @@ func (c *EndpointSliceConfig) handleDeleteEndpointSlice(obj interface{}) {
 		}
 	}
 	for _, h := range c.eventHandlers {
-		if endpointSlice.Namespace != known.SyncNamespace {
-			klog.Infof("EndpointSliceConfig.handleDeleteEndpointSlice will not deal: %v/%v",
-				endpointSlice.Namespace, endpointSlice.Name)
-			continue
-		}
-
 		klog.V(4).InfoS("Calling handler.OnEndpointsDelete", "endpointslice", klog.KObj(endpointSlice))
 		h.OnEndpointSliceDelete(endpointSlice)
 	}

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -123,12 +123,12 @@ func newEndpointSliceTracker() *endpointSliceTracker {
 func newEndpointSliceInfo(endpointSlice *discovery.EndpointSlice, remove bool) *endpointSliceInfo {
 	nameLabel, ok := endpointSlice.Labels[known.LabelServiceName]
 	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no name label", "serviceImport", klog.KObj(endpointSlice))
+		klog.ErrorS(nil, "EndpointSlice has no name label", "EndpointSlice", klog.KObj(endpointSlice))
 		return nil
 	}
 	namespaceLabel, ok := endpointSlice.Labels[known.LabelServiceNameSpace]
 	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no namespace label", "serviceImport",
+		klog.ErrorS(nil, "EndpointSlice has no namespace label", "EndpointSlice",
 			klog.KObj(endpointSlice))
 		return nil
 	}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -50,7 +50,6 @@ import (
 	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
-	"github.com/fleetboard-io/fleetboard/pkg/known"
 	"github.com/fleetboard-io/fleetboard/pkg/proxy"
 )
 
@@ -471,20 +470,9 @@ type servicePortInfo struct {
 func newServiceInfo(port *v1.ServicePort, serviceImport *v1alpha1.ServiceImport,
 	bsvcPortInfo *proxy.BaseServicePortInfo) proxy.ServicePort {
 	svcPort := &servicePortInfo{BaseServicePortInfo: bsvcPortInfo}
-	// get service name and namespace
-	nameLabel, ok := serviceImport.Labels[known.LabelServiceName]
-	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no name label", "serviceImport", klog.KObj(serviceImport))
-		return nil
-	}
-	namespaceLabel, ok := serviceImport.Labels[known.LabelServiceNameSpace]
-	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no namespace label", "serviceImport", klog.KObj(serviceImport))
-		return nil
-	}
 
 	// Store the following for performance reasons.
-	svcName := types.NamespacedName{Namespace: namespaceLabel, Name: nameLabel}
+	svcName := types.NamespacedName{Namespace: serviceImport.Namespace, Name: serviceImport.Name}
 	svcPortName := proxy.ServicePortName{NamespacedName: svcName, Port: port.Name}
 	svcPort.nameString = svcPortName.String()
 

--- a/pkg/proxy/service_import.go
+++ b/pkg/proxy/service_import.go
@@ -31,8 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/metrics"
 	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
-
-	"github.com/fleetboard-io/fleetboard/pkg/known"
 )
 
 // BaseServicePortInfo contains base information that defines a service.
@@ -315,20 +313,8 @@ func (sct *ServiceImportChangeTracker) serviceImportToServiceMap(serviceImport *
 		return nil
 	}
 
-	// get service name and namespace
-	nameLabel, ok := serviceImport.Labels[known.LabelServiceName]
-	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no name label", "serviceImport", klog.KObj(serviceImport))
-		return nil
-	}
-	namespaceLabel, ok := serviceImport.Labels[known.LabelServiceNameSpace]
-	if !ok {
-		klog.ErrorS(nil, "ServiceImport has no namespace label", "serviceImport", klog.KObj(serviceImport))
-		return nil
-	}
-
 	svcPortMap := make(ServicePortMap)
-	svcName := types.NamespacedName{Namespace: namespaceLabel, Name: nameLabel}
+	svcName := types.NamespacedName{Namespace: serviceImport.Namespace, Name: serviceImport.Name}
 	for i := range serviceImport.Spec.Ports {
 		servicePort := serviceImport.Spec.Ports[i]
 

--- a/pkg/tunnel/options.go
+++ b/pkg/tunnel/options.go
@@ -23,8 +23,6 @@ type Options struct {
 	HubSecretName string
 	// used to share endpoint slices in hub
 	ShareNamespace string
-	// used to store endpoint slices in local clusters
-	LocalNamespace string
 	// true means run as hub
 	AsHub bool
 	// true means run as cluster
@@ -62,10 +60,6 @@ func (o *Options) Validate() []error {
 
 	if len(o.ShareNamespace) == 0 {
 		allErrors = append(allErrors, fmt.Errorf("--shared-namespace must be specified"))
-	}
-
-	if o.AsCluster && len(o.LocalNamespace) == 0 {
-		allErrors = append(allErrors, fmt.Errorf("--local-namespace must be specified when run as cluster"))
 	}
 
 	if o.AsCluster && len(o.HubSecretNamespace) == 0 {
@@ -113,9 +107,6 @@ func (o *Options) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&o.ShareNamespace, "shared-namespace", o.ShareNamespace,
 		"shared namespace in hub used to share endpoint slices across clusters")
-
-	fs.StringVar(&o.LocalNamespace, "local-namespace", o.LocalNamespace,
-		"local namespace in cluster used to share endpoint slices across clusters")
 
 	return fss
 }

--- a/utils/endpointslice.go
+++ b/utils/endpointslice.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,10 +140,10 @@ func GetServiceCIDRFromCNFPod(kubeClientSet kubernetes.Interface) (string, error
 }
 
 // GetServiceCIDR get existing virtual service CIDR and IPs
-func GetServiceCIDR(mcsClientSet *mcsclientset.Clientset, targetNamespace string,
+func GetServiceCIDR(mcsClientSet *mcsclientset.Clientset,
 	kubeClientSet kubernetes.Interface) (string, []string, error) {
 	var virtualServiceIPs []string
-	if localSIList, err := mcsClientSet.MulticlusterV1alpha1().ServiceImports(targetNamespace).
+	if localSIList, err := mcsClientSet.MulticlusterV1alpha1().ServiceImports(v1.NamespaceAll).
 		List(context.Background(), metav1.ListOptions{}); err != nil {
 		return "", nil, fmt.Errorf("failed to list service import: %v", err)
 	} else {
@@ -174,9 +175,8 @@ func GetServiceCIDR(mcsClientSet *mcsclientset.Clientset, targetNamespace string
 }
 
 // InitNewCIDR init a CIDR to allocate local-cluster-range ip for imported multi-cluster virtual services
-func (i *IPAM) InitNewCIDR(mcsClientSet *mcsclientset.Clientset, targetNamespace string,
-	kubeClientSet kubernetes.Interface) (string, error) {
-	newCIDR, virtualServiceIPs, err := GetServiceCIDR(mcsClientSet, targetNamespace, kubeClientSet)
+func (i *IPAM) InitNewCIDR(mcsClientSet *mcsclientset.Clientset, kubeClientSet kubernetes.Interface) (string, error) {
+	newCIDR, virtualServiceIPs, err := GetServiceCIDR(mcsClientSet, kubeClientSet)
 	if err != nil {
 		return "", fmt.Errorf("failed to get service CIDR: %v", err)
 	}


### PR DESCRIPTION
1.  remove local syncer-operator namespace
2.  make serviceimport in user namespace
3. be noted that, karmada will rollback and retain serviceimport.spec.ips, so we will add a [ResourceInterpreterCustomization](https://github.com/karmada-io/karmada/blob/84b971a501ba82c53a5ad455c2fe84d842cd7d4e/pkg/apis/config/v1alpha1/resourceinterpretercustomization_types.go#L17) in karmada controll plane with resourceinterpretercustomization.yaml :
 
```
apiVersion: config.karmada.io/v1alpha1
kind: ResourceInterpreterCustomization
metadata:
  name: declarative-configuration-example
spec:
  target:
    apiVersion: multicluster.x-k8s.io/v1alpha1
    kind: ServiceImport
  customizations:
    retention:
      luaScript: >
        function Retain(desiredObj, observedObj)
          desiredObj.spec.ips = observedObj.spec.ips
          return desiredObj
        end
```
and scripts:


`kubectl karmada create -f resourceinterpretercustomization.yaml --kubeconfig=/etc/karmada/karmada-apiserver.config`